### PR TITLE
feat(#4): collect all errors

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -39,9 +39,16 @@ jobs:
         pylint --disable=consider-using-f-string abcmeta/
     - name: Test
       run: |
+        TEST_1="AttributeError: Derived class 'ABCDerived' has not implemented 'method_1' method of the parent class 'ABCParent'"
+        TEST_2="Derived method expected to get 3 parameters but gets 2"
+        TEST_3="Derived method expected to get 'name:<class 'str'>' paramter's type, but gets 'name:<class 'int'>'"
+        TEST_4="Derived method expected to get 'name' paramter, but gets 'family'"
+        TEST_5="Derived method expected to return in 'typing.Dict[str, str]' type, but returns 'typing.Dict[str, int]'"
+        TEST_MULTI="$TEST_1\|Derived method expected to get 'name:<class 'str'>' paramter's type, but gets 'name:<class 'int'>'\|$TEST_4"
         PYTHONPATH=. python tests/correct_class_test.py
-        PYTHONPATH=. python tests/incorrect_class_1_test.py |& grep -F "AttributeError: Derived class 'ABCDerived' has not implemented 'method_1' method of the parent class 'ABCParent'"
-        PYTHONPATH=. python tests/incorrect_class_2_test.py |& grep -F "Derived method expected to get 3 parameters but gets 2"
-        PYTHONPATH=. python tests/incorrect_class_3_test.py |& grep -F "Derived method expected to get 'name:<class 'str'>' paramter's type, but gets 'name:<class 'int'>'"
-        PYTHONPATH=. python tests/incorrect_class_4_test.py |& grep -F "Derived method expected to get 'name' paramter, but gets 'family'"
-        PYTHONPATH=. python tests/incorrect_class_5_test.py |& grep -F "Derived method expected to return in 'typing.Dict[str, str]' type, but returns 'typing.Dict[str, int]'"
+        PYTHONPATH=. python tests/incorrect_class_1_test.py |& grep -F $TEST_1
+        PYTHONPATH=. python tests/incorrect_class_2_test.py |& grep -F $TEST_2
+        PYTHONPATH=. python tests/incorrect_class_3_test.py |& grep -F $TEST_3
+        PYTHONPATH=. python tests/incorrect_class_4_test.py |& grep -F $TEST_4
+        PYTHONPATH=. python tests/incorrect_class_5_test.py |& grep -F $TEST_5
+        PYTHONPATH=. python tests/multiple_incorrect_methods_test.py |& grep -cG $TEST_MULTI | grep 3

--- a/abcmeta/__init__.py
+++ b/abcmeta/__init__.py
@@ -140,6 +140,7 @@ class ABC(metaclass=BuiltinABCMeta):
         """Python built-in method."""
         super().__init_subclass__()
 
+        errors = []
         for name, obj in vars(cls.__base__).items():
 
             # Ignore uncallable methods.
@@ -156,12 +157,13 @@ class ABC(metaclass=BuiltinABCMeta):
 
             # Make sure the derived class has implemented the abstract method.
             if name not in cls.__dict__:
-                raise AttributeError(
+                errors.append(
                     "Derived class '{}' has not implemented '{}' method of the"
                     " parent class '{}'.".format(
                         cls.__name__, name, cls.__base__.__name__
                     )
                 )
+                continue
 
             derived_method = getattr(cls, name)
 
@@ -181,7 +183,10 @@ class ABC(metaclass=BuiltinABCMeta):
                 diff_details = _compare_signatures_details(
                     obj_method_signature, derived_method_signature
                 )
-                raise AttributeError(
+                errors.append(
                     "Signature of the derived method is not the same as parent"
                     " class:\r\n{}".format(_prepare_text_to_raise(diff, diff_details))
                 )
+
+        if errors:
+            raise AttributeError("\n\n".join(errors))

--- a/tests/multiple_incorrect_methods_test.py
+++ b/tests/multiple_incorrect_methods_test.py
@@ -1,0 +1,35 @@
+"""Test for abcmeta library.
+
+Test for multiple errors.
+"""
+from typing import Dict, Text, Tuple
+
+from abcmeta import ABC, abstractmethod
+
+
+class ABCParent(ABC):
+    @abstractmethod
+    def method_1(self, name, age):
+        pass
+
+    @abstractmethod
+    def method_2(self, name: Text, age: int) -> Dict[Text, Text]:
+        """Abstract method."""
+
+    def method_3(self):
+        pass
+
+    @abstractmethod
+    def method_4(self, name: Text, age: int) -> Tuple[Text, Text]:
+        """Abstract method."""
+
+
+class ABCDerived(ABCParent):
+    def method_(self, name, age): # Intentional typo (Same error as Test 1)
+        pass
+
+    def method_2(self, name: int, age: int) -> Dict[Text, Text]:  # New
+        return {"name": "test"}
+
+    def method_4(self, family: Text, age: int) -> Tuple[Text, Text]:  # Test 4
+        return ("name", "test")


### PR DESCRIPTION
Fixes #4 

Adds feature and tests for printing multiple errors are once

```sh
> python tests/multiple_incorrect_methods_test.py
Traceback (most recent call last):
  File "/Users/kyleking/Developer/Pull_Requests/abcmeta/tests/multiple_incorrect_methods_test.py", line 27, in <module>
    class ABCDerived(ABCParent):
  File "/Users/kyleking/.asdf/installs/python/3.10.5/lib/python3.10/abc.py", line 106, in __new__
    cls = super().__new__(mcls, name, bases, namespace, **kwargs)
  File "/Users/kyleking/.asdf/installs/python/3.10.5/lib/python3.10/site-packages/abcmeta/__init__.py", line 192, in __init_subclass__
    raise AttributeError("\n\n".join(errors))
AttributeError: Derived class 'ABCDerived' has not implemented 'method_1' method of the parent class 'ABCParent'.

Signature of the derived method is not the same as parent class:
- method_2(self, name: str, age: int) -> Dict[str, str]
?                      ^ -

+ method_2(self, name: int, age: int) -> Dict[str, str]
?                      ^^

Derived method expected to get 'name:<class 'str'>' paramter's type, but gets 'name:<class 'int'>'

Signature of the derived method is not the same as parent class:
- method_4(self, name: str, age: int) -> Tuple[str, str]
?                ^  ^

+ method_4(self, family: str, age: int) -> Tuple[str, str]
?                ^  ^^^

Derived method expected to get 'name' paramter, but gets 'family'
```

Only downside is that maybe the join on 2x `\n` could be more clear. Should it be something involving dashes like `'-' * 80` or 3x `\n`?